### PR TITLE
ADF-101 finished notification blink

### DIFF
--- a/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
@@ -201,9 +201,8 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
             // Null out this task id since we're no longer listening for it 3/2/16 [KV]
             mTaskIdToListenOn = null;
         }
-        // Remove any if one is already showing
-        mNotificationManager.cancel(mFinishedNotificationId);
-        showNotificationFinish();
+
+        showOrUpdateNotificationFinish();
         super.onTaskSuccess(task);
     }
 
@@ -276,9 +275,11 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
     }
 
     /**
-     * Shows an entirely separate notification
+     * Shows an entirely separate notification.
+     * If the notification is already showing,
+     * the current notification will be updated.
      */
-    private void showNotificationFinish() {
+    private void showOrUpdateNotificationFinish() {
         Notification.Builder builder = new Notification.Builder(this)
                 // Example: "Upload finished"
                 .setTicker(mFinishedNotificationTitleString)


### PR DESCRIPTION
#### Ticket
[ADF-101](https://vimean.atlassian.net/browse/ADF-101)

#### Ticket Summary
When a task finished, the "finished" notification would be removed and re-added to the notification manager. This caused a blink effect. Instead the current notification should just be updated.

#### Implementation Summary
There was an unnecessary `cancel()` call in the `NotificationTaskService` that I removed. I also renamed the internal method so that it was more clear.

#### How to Test
1. Run a bunch of tasks in the sample app.
2. Notice that the finished notification isn't re-added every time a task finishes.
