### PR TITLE
Allowing injection of custom gson instance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 08 09:55:28 EDT 2016
+#Thu Mar 30 11:42:44 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/sample/src/main/java/com/vimeo/sample/tasks/SimpleTaskManager.java
+++ b/sample/src/main/java/com/vimeo/sample/tasks/SimpleTaskManager.java
@@ -3,6 +3,9 @@ package com.vimeo.sample.tasks;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.vimeo.turnstile.BaseTaskManager;
 import com.vimeo.turnstile.BaseTaskService;
 
@@ -30,6 +33,13 @@ public class SimpleTaskManager extends BaseTaskManager<SimpleTask> {
     @Override
     protected Class<? extends BaseTaskService> getServiceClass() {
         return SimpleTaskService.class;
+    }
+
+    @NonNull
+    @Override
+    protected Gson createGson() {
+        return new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                .create();
     }
 
     @NonNull

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
@@ -205,6 +205,11 @@ public abstract class BaseTask implements Serializable, Callable {
      */
     private transient int mProgress;
 
+    /**
+     * True if the task is currently running, false otherwise.
+     */
+    private transient volatile boolean mIsRunning;
+
     // ---- Task Specific Fields ----
     /**
      * Unique identifier for this task
@@ -232,8 +237,6 @@ public abstract class BaseTask implements Serializable, Callable {
      */
     @SerializedName("created_at")
     protected final long mCreatedTimeMillis;
-
-    private volatile boolean mIsRunning;
     // </editor-fold>
 
     // -----------------------------------------------------------------------------------------------------

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
@@ -30,6 +30,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
+import com.google.gson.Gson;
 import com.vimeo.turnstile.BaseTask.TaskStateListener;
 import com.vimeo.turnstile.TaskConstants.ManagerEvent;
 import com.vimeo.turnstile.TaskConstants.TaskEvent;
@@ -274,7 +275,7 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
 
         // ---- Persistence ----
         // Synchronous load from SQLite. Not very performant but required for simplified in-memory cache
-        mTaskCache = new TaskCache<>(mContext, taskName, taskClass);
+        mTaskCache = new TaskCache<>(mContext, taskName, taskClass, createGson());
 
         // ---- Boot Handling ----
         if (startOnDeviceBoot() && getServiceClass() != null) {
@@ -299,6 +300,15 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
      */
     @Nullable
     protected abstract Class<? extends BaseTaskService> getServiceClass();
+
+    /**
+     * Create a Gson instance that will be used to serialize
+     * and deserialize your extended version of {@link BaseTask}.
+     *
+     * @return should return a non null Gson instance.
+     */
+    @NonNull
+    protected abstract Gson createGson();
 
     /**
      * The unique name used to identify this particular subclass of {@link BaseTaskManager}.

--- a/turnstile/src/main/java/com/vimeo/turnstile/database/TaskCache.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/database/TaskCache.java
@@ -30,6 +30,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 
+import com.google.gson.Gson;
 import com.vimeo.turnstile.BaseTask;
 import com.vimeo.turnstile.utils.TaskLogger;
 
@@ -75,8 +76,11 @@ public final class TaskCache<T extends BaseTask> {
     }
 
     @WorkerThread
-    public TaskCache(@NonNull Context context, @NonNull String taskName, @NonNull Class<T> taskClass) {
-        mDatabase = new TaskDatabase<>(context, taskName, taskClass);
+    public TaskCache(@NonNull Context context,
+                     @NonNull String taskName,
+                     @NonNull Class<T> taskClass,
+                     @NonNull Gson gson) {
+        mDatabase = new TaskDatabase<>(context, taskName, taskClass, gson);
         List<T> tasks = mDatabase.getTasks(null);
         for (T task : tasks) {
             mTaskMap.put(task.getId(), task);

--- a/turnstile/src/main/java/com/vimeo/turnstile/database/TaskDatabase.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/database/TaskDatabase.java
@@ -32,13 +32,11 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 
-import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.vimeo.turnstile.BaseTask;
 import com.vimeo.turnstile.BaseTask.TaskState;
-import com.vimeo.turnstile.utils.TaskLogger;
 import com.vimeo.turnstile.database.SqlHelper.SqlProperty;
+import com.vimeo.turnstile.utils.TaskLogger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -83,16 +81,17 @@ class TaskDatabase<T extends BaseTask> {
         IO_THREAD.execute(runnable);
     }
 
-    public TaskDatabase(Context context, String name, Class<T> taskClass) {
+    public TaskDatabase(@NonNull Context context,
+                        @NonNull String name,
+                        @NonNull Class<T> taskClass,
+                        @NonNull Gson gson) {
         SqlProperty[] PROPERTIES = {ID_COLUMN, STATE_COLUMN, TASK_COLUMN, CREATE_AT_COLUMN};
         mHelper = new DbOpenHelper(context, name, DATABASE_VERSION, ID_COLUMN, PROPERTIES);
         mDatabase = mHelper.getWritableDatabase();
         mSqlHelper = new SqlHelper(mDatabase, mHelper.getTableName(), ID_COLUMN.columnName, PROPERTIES);
 
         mTaskClass = taskClass;
-        mGsonSerializer =
-                new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-                        .create();
+        mGsonSerializer = gson;
     }
 
     private void bindValues(SQLiteStatement stmt, T task) {

--- a/turnstile/src/test/java/com/vimeo/turnstile/database/DummyDatabaseInstances.java
+++ b/turnstile/src/test/java/com/vimeo/turnstile/database/DummyDatabaseInstances.java
@@ -1,5 +1,8 @@
 package com.vimeo.turnstile.database;
 
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.vimeo.turnstile.dummy.UnitTestBaseTask;
 
 import org.robolectric.RuntimeEnvironment;
@@ -13,7 +16,8 @@ final class DummyDatabaseInstances {
     }
 
     public static TaskDatabase<UnitTestBaseTask> newDatabase() {
-        return new TaskDatabase<>(RuntimeEnvironment.application, "test", UnitTestBaseTask.class);
+        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+        return new TaskDatabase<>(RuntimeEnvironment.application, "test", UnitTestBaseTask.class, gson);
     }
 
 }

--- a/turnstile/src/test/java/com/vimeo/turnstile/dummy/DummyClassInstances.java
+++ b/turnstile/src/test/java/com/vimeo/turnstile/dummy/DummyClassInstances.java
@@ -1,5 +1,8 @@
 package com.vimeo.turnstile.dummy;
 
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.vimeo.turnstile.database.TaskCache;
 
 import org.robolectric.RuntimeEnvironment;
@@ -10,7 +13,8 @@ public final class DummyClassInstances {
     }
 
     public static TaskCache<UnitTestBaseTask> newTaskCache() {
-        return new TaskCache<>(RuntimeEnvironment.application, "test", UnitTestBaseTask.class);
+        Gson gson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES).create();
+        return new TaskCache<>(RuntimeEnvironment.application, "test", UnitTestBaseTask.class, gson);
     }
 
 }


### PR DESCRIPTION
#### Summary
We experienced some trouble with json deserialization due to a mistake on our part where a plain gson object was serializing our models differently than expected. We made the assumption that we were using a custom gson object, which was not the case. In order for us to handle this scenario correctly, we need to be able to inject our own gson instance into the library.

#### Implementation Summary
1. Updated the gradle version used.
2. Fixed a field in `BaseTask` that should not have been serialized so that it is no longer serialized.
3. Added support for custom gson as an abstract method in the `BaseTaskManager`. This forces the consumer to specify the gson object that should be used. It could be optional. 

A better approach would be to change the architecture of the library so that BaseTask is not abstract but concrete, and the consumer implements an interface that is responsible for its own (de)serialization. However, this is a temporary solution in case that a larger re-architecture is not possible.
