### PR TITLE
Turnstile background service crashes on Android Oreo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ android:
   - tools
   - platform-tools
   - platform-tools-preview
-  - android-25
-  - build-tools-25.0.2
+  - android-26
+  - build-tools-26.0.2
   - extra-android-m2repository
   - extra-google-google_play_services
   - extra-google-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url "https://maven.google.com" }
         jcenter()
     }
     tasks.withType(Javadoc).all { enabled = false }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -17,6 +17,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    lintOptions {
+        abortOnError false
+    }
 }
 
 dependencies {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.2"
 
     defaultConfig {
         applicationId "com.vimeo.sample"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0.0"
     }
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
 
     compile project(':turnstile')
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:26.1.0'
 
     compile project(':turnstile')
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
             android:name=".tasks.SimpleTaskService"
             android:enabled="true"
             android:exported="false"/>
+
+        <receiver android:name=".TestAlarmReceiver"/>
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/vimeo/sample/App.java
+++ b/sample/src/main/java/com/vimeo/sample/App.java
@@ -1,6 +1,9 @@
 package com.vimeo.sample;
 
+import android.app.AlarmManager;
 import android.app.Application;
+import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
 
 import com.vimeo.sample.tasks.SimpleConditions;
@@ -40,5 +43,17 @@ public class App extends Application {
         taskTaskManagerBuilder.withNotificationIntent(intent);
 
         SimpleTaskManager.initialize(taskTaskManagerBuilder);
+
+        // Uncomment to test adding a task when the app isn't in the foreground.
+//        startAlarmBroadcastReceiver(this, 5000);
+    }
+
+    public static void startAlarmBroadcastReceiver(Context context, long delay) {
+        Intent _intent = new Intent(context, TestAlarmReceiver.class);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, _intent, 0);
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        // Remove any previous pending intent.
+        alarmManager.cancel(pendingIntent);
+        alarmManager.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + delay, pendingIntent);
     }
 }

--- a/sample/src/main/java/com/vimeo/sample/TestAlarmReceiver.java
+++ b/sample/src/main/java/com/vimeo/sample/TestAlarmReceiver.java
@@ -1,0 +1,23 @@
+package com.vimeo.sample;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.widget.Toast;
+
+import com.vimeo.sample.tasks.SimpleTask;
+import com.vimeo.sample.tasks.SimpleTaskManager;
+import com.vimeo.turnstile.utils.UniqueIdGenerator;
+
+/**
+ * Created by kylevenn on 10/30/17.
+ */
+public class TestAlarmReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        Toast.makeText(context, "Alarm received", Toast.LENGTH_LONG).show();
+        SimpleTaskManager
+                .getInstance()
+                .addTask(new SimpleTask(UniqueIdGenerator.generateId()));
+    }
+}

--- a/sample/src/main/java/com/vimeo/sample/tasks/SimpleTask.java
+++ b/sample/src/main/java/com/vimeo/sample/tasks/SimpleTask.java
@@ -25,15 +25,18 @@ public class SimpleTask extends BaseTask {
 
         try {
             // Sleep for 5 seconds to simulate work being done
-            Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+            int totalSleepDuration = 10;
+            int sleepIncrements = 5;
+            int incrementalSleepDuration = totalSleepDuration / sleepIncrements;
+            Thread.sleep(TimeUnit.SECONDS.toMillis(incrementalSleepDuration));
             onTaskProgress(20);
-            Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+            Thread.sleep(TimeUnit.SECONDS.toMillis(incrementalSleepDuration));
             onTaskProgress(40);
-            Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+            Thread.sleep(TimeUnit.SECONDS.toMillis(incrementalSleepDuration));
             onTaskProgress(60);
-            Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+            Thread.sleep(TimeUnit.SECONDS.toMillis(incrementalSleepDuration));
             onTaskProgress(80);
-            Thread.sleep(TimeUnit.SECONDS.toMillis(1));
+            Thread.sleep(TimeUnit.SECONDS.toMillis(incrementalSleepDuration));
         } catch (InterruptedException e) {
             TaskLogger.getLogger().e("Task interrupted", e);
         }

--- a/turnstile/build.gradle
+++ b/turnstile/build.gradle
@@ -27,12 +27,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 25 // Update .travis.yml android.components.android-*
-    buildToolsVersion "25.0.2" // Update .travis.yml android.components.build-tools-*
+    compileSdkVersion 26 // Update .travis.yml android.components.android-*
+    buildToolsVersion "26.0.2" // Update .travis.yml android.components.build-tools-*
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionName project.version
     }
 }
@@ -40,7 +40,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.1.2'
-    compile 'com.android.support:support-annotations:25.1.1'
+    compile 'com.android.support:support-annotations:25.3.1'
     compile 'com.google.code.gson:gson:2.7'
 }
 

--- a/turnstile/build.gradle
+++ b/turnstile/build.gradle
@@ -40,7 +40,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.1.2'
-    compile 'com.android.support:support-annotations:25.3.1'
+    compile 'com.android.support:support-annotations:26.1.0'
     compile 'com.google.code.gson:gson:2.7'
 }
 

--- a/turnstile/src/main/AndroidManifest.xml
+++ b/turnstile/src/main/AndroidManifest.xml
@@ -1,16 +1,17 @@
-<manifest
-    package="com.vimeo.turnstile"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.vimeo.turnstile">
 
     <!-- Start Upload Service on Boot -->
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application>
 
-        <receiver android:name="com.vimeo.turnstile.BootReceiver">
+        <receiver
+            android:name="com.vimeo.turnstile.BootReceiver"
+            android:enabled="@bool/boot_receiver_enabled">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
     </application>

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
@@ -816,13 +816,18 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
         }
     }
 
+    /**
+     * This method will start the {@link BaseTaskService} based on the
+     * {@link #getServiceClass()}.
+     * This method is called when we know the service should be running.
+     * Examples of this would include:
+     * <ol>
+     * <li>When a task is added.</li>
+     * <li>We know there are unfinished tasks in the queue.</li>
+     * </ol>
+     */
     protected void startService() {
-        // Call this method when we know the service should be running
-        // (we just added a task or we know there are unfinished tasks).
-        if (getServiceClass() != null) {
-            Intent startServiceIntent = new Intent(mContext, getServiceClass());
-            mContext.startService(startServiceIntent);
-        }
+        BaseTaskService.startTaskService(mContext, getServiceClass());
     }
 
     private void killService(boolean taskCompleted) {

--- a/turnstile/src/main/java/com/vimeo/turnstile/BootReceiver.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BootReceiver.java
@@ -28,7 +28,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.RequiresPermission;
-import android.widget.Toast;
 
 import com.vimeo.turnstile.utils.BootPreferences;
 import com.vimeo.turnstile.utils.TaskLogger;
@@ -47,7 +46,6 @@ public final class BootReceiver extends BroadcastReceiver {
     @Override
     @RequiresPermission(Manifest.permission.RECEIVE_BOOT_COMPLETED)
     public void onReceive(final Context context, Intent intent) {
-        Toast.makeText(context, "Boot received", Toast.LENGTH_LONG).show();
         if (intent != null && Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
             TaskLogger.getLogger().d("BootReceiver onReceive for TaskManager");
             // Reading SharedPreferences can take a little time initially since it requires reading from disk.

--- a/turnstile/src/main/java/com/vimeo/turnstile/BootReceiver.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BootReceiver.java
@@ -28,6 +28,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.RequiresPermission;
+import android.widget.Toast;
 
 import com.vimeo.turnstile.utils.BootPreferences;
 import com.vimeo.turnstile.utils.TaskLogger;
@@ -46,6 +47,7 @@ public final class BootReceiver extends BroadcastReceiver {
     @Override
     @RequiresPermission(Manifest.permission.RECEIVE_BOOT_COMPLETED)
     public void onReceive(final Context context, Intent intent) {
+        Toast.makeText(context, "Boot received", Toast.LENGTH_LONG).show();
         if (intent != null && Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
             TaskLogger.getLogger().d("BootReceiver onReceive for TaskManager");
             // Reading SharedPreferences can take a little time initially since it requires reading from disk.
@@ -55,10 +57,8 @@ public final class BootReceiver extends BroadcastReceiver {
                 @Override
                 public void run() {
                     for (Class serviceClass : BootPreferences.getServiceClasses(context)) {
-                        TaskLogger.getLogger().d("Starting service: " + serviceClass.getSimpleName());
-                        Intent startServiceIntent = new Intent(context, serviceClass);
                         // The service will be started on the main thread 3/2/16 [KV]
-                        context.startService(startServiceIntent);
+                        BaseTaskService.startTaskService(context, serviceClass);
                     }
                 }
             }).start();

--- a/turnstile/src/main/java/com/vimeo/turnstile/BootReceiver.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BootReceiver.java
@@ -32,6 +32,7 @@ import android.support.annotation.RequiresPermission;
 import com.vimeo.turnstile.utils.BootPreferences;
 import com.vimeo.turnstile.utils.TaskLogger;
 
+
 /**
  * The express purpose of this class is to register for
  * the device startup event. This is to allow for starting

--- a/turnstile/src/main/res/values-v26/bools.xml
+++ b/turnstile/src/main/res/values-v26/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="boot_receiver_enabled">false</bool>
+</resources>

--- a/turnstile/src/main/res/values/bools.xml
+++ b/turnstile/src/main/res/values/bools.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="boot_receiver_enabled">true</bool>
+</resources>


### PR DESCRIPTION
As far as roll out, once this is merged into develop, I will cut an alpha release which the Vimeo app will then point to.

#### Issue Summary
Upon rebooting the device, we saw that turnstile was causing a crash. "Vimeo has stopped working" would appear and the automatically dismiss 2 minutes after the device started back up.

#### Implementation Summary
This is due to a change made in Android Oreo (API 26) which doesn't allow for background services to be started (unless explicitly calling `startForegroundService()`). To get a working version, we'll catch any service related crashes only on API 26 and up. As a long term fix, we'll use `stareForegroundService()` when appropriate and non-foreground services will either be converted to use job scheduler or will just have to run when the device is in the foreground.

I've added a helper method to BaseTaskService (which will eventually be moved to a utility class when it isn't just a patch). This method is where the catch happens. I've also disabled the boot receiver on Android O so that unless your app has an additional boot receiver, we won't have the opportunity to throw the exception in the first place. On Android O, the tasks will start executing once your app is foregrounded (automatically).

#### How to Test
On Android O, start the sample project and immediately force close it. The alarm boot receiver I've added will simulate what happens when a task is added in the background.

On Android O, start some tasks in the sample project and then immediately reboot the device. There should be no crash when it starts back up. Then when you re-open the app, all the tasks should execute (and resume correctly if it is supported).

On pre-O, it should behave the same as it did before.
