### PR TITLE
Notification Channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ android:
   - tools
   - platform-tools
   - platform-tools-preview
-  - android-26
-  - build-tools-26.0.2
+  - android-27
+  - build-tools-27.0.3
   - extra-android-m2repository
   - extra-google-google_play_services
   - extra-google-m2repository

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.2"
+    compileSdkVersion 27
+    buildToolsVersion "27.0.3"
 
     defaultConfig {
         applicationId "com.vimeo.sample"
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 1
         versionName "1.0.0"
     }
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:26.1.0'
+    compile 'com.android.support:appcompat-v7:27.0.2'
 
     compile project(':turnstile')
 }

--- a/sample/src/main/java/com/vimeo/sample/tasks/SimpleTaskService.java
+++ b/sample/src/main/java/com/vimeo/sample/tasks/SimpleTaskService.java
@@ -6,6 +6,8 @@ import com.vimeo.turnstile.NotificationTaskService;
 
 public class SimpleTaskService extends NotificationTaskService<SimpleTask> {
 
+    private static final String SAMPLE_NOTIFICATION_CHANNEL_ID = "turnstile-notifications-channel";
+
     @Override
     protected void handleAdditionalEvents(String event) {
 
@@ -43,6 +45,21 @@ public class SimpleTaskService extends NotificationTaskService<SimpleTask> {
     @Override
     protected int getNetworkNotificationMessageStringRes() {
         return R.string.network_problems;
+    }
+
+    @Override
+    protected String getNotificationChannelId() {
+        return SAMPLE_NOTIFICATION_CHANNEL_ID;
+    }
+
+    @Override
+    protected int getNotificationChannelName() {
+        return R.string.notification_channel_name;
+    }
+
+    @Override
+    protected int getNotificationChannelDescription() {
+        return R.string.notification_channel_description;
     }
 
     @Override

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,6 +1,8 @@
 <resources>
     <string name="app_name">Sample</string>
     <string name="notification_click">Notification clicked!</string>
+    <string name="notification_channel_name">Sample Channel</string>
+    <string name="notification_channel_description">Sample Channel Description</string>
     <string name="started_text">Started task, id: %1$s</string>
     <string name="added_text">Added task, id: %1$s</string>
     <string name="result_text">Task completed, id: %1$s</string>

--- a/turnstile/build.gradle
+++ b/turnstile/build.gradle
@@ -27,12 +27,12 @@ ext {
 }
 
 android {
-    compileSdkVersion 26 // Update .travis.yml android.components.android-*
-    buildToolsVersion "26.0.2" // Update .travis.yml android.components.build-tools-*
+    compileSdkVersion 27 // Update .travis.yml android.components.android-*
+    buildToolsVersion "27.0.3" // Update .travis.yml android.components.build-tools-*
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionName project.version
     }
 }
@@ -40,7 +40,7 @@ android {
 dependencies {
     testCompile 'junit:junit:4.12'
     testCompile 'org.robolectric:robolectric:3.1.2'
-    compile 'com.android.support:support-annotations:26.1.0'
+    compile 'com.android.support:support-annotations:27.0.2'
     compile 'com.google.code.gson:gson:2.7'
 }
 

--- a/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
@@ -25,13 +25,19 @@
 package com.vimeo.turnstile;
 
 import android.app.Notification;
+import android.app.Notification.Builder;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Intent;
+import android.os.Build;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.PluralsRes;
+import android.support.annotation.RequiresApi;
 import android.support.annotation.StringRes;
 
 /**
@@ -41,6 +47,8 @@ import android.support.annotation.StringRes;
  * Created by zetterstromk on 8/10/16.
  */
 public abstract class NotificationTaskService<T extends BaseTask> extends BaseTaskService<T> {
+
+    private static final String DEFAULT_NOTIFICATION_CHANNEL_ID = "turnstile_notification_channel";
 
     /**
      * Unique id for the notification. We use it on notification start and to cancel it.
@@ -143,6 +151,22 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
     protected abstract int getProgressNotificationTitleStringRes();
 
     /**
+     * The notification channel name.
+     *
+     * @return the string resource for the notification channel name.
+     */
+    @StringRes
+    protected abstract int getNotificationChannelName();
+
+    /**
+     * The notification channel description.
+     *
+     * @return the string resource for the notification channel description.
+     */
+    @StringRes
+    protected abstract int getNotificationChannelDescription();
+
+    /**
      * The icon for the progress notification.
      *
      * @return the id of the drawable to use for the progress notification.
@@ -230,7 +254,15 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
      * Show a notification while this service is running.
      */
     protected void setupNotification() {
-        mProgressNotificationBuilder = new Notification.Builder(this).setSmallIcon(getProgressIconDrawable())
+        if (VERSION.SDK_INT >= VERSION_CODES.O) {
+            createChannel();
+            mProgressNotificationBuilder = new Builder(this, DEFAULT_NOTIFICATION_CHANNEL_ID);
+        } else {
+            mProgressNotificationBuilder = new Builder(this);
+        }
+
+        mProgressNotificationBuilder
+                .setSmallIcon(getProgressIconDrawable())
                 .setTicker(getString(R.string.notification_started))
                 .setProgress(100, 0, true)
                 // Example: "Uploading video"
@@ -280,9 +312,17 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
      * the current notification will be updated.
      */
     private void showOrUpdateNotificationFinish() {
-        Notification.Builder builder = new Notification.Builder(this)
-                // Example: "Upload finished"
+        final Notification.Builder builder;
+        if (VERSION.SDK_INT >= VERSION_CODES.O) {
+            createChannel();
+            builder = new Builder(this, DEFAULT_NOTIFICATION_CHANNEL_ID);
+        } else {
+            builder = new Builder(this);
+        }
+
+         builder
                 .setTicker(mFinishedNotificationTitleString)
+                 // Example: "Upload finished"
                 .setContentTitle(mFinishedNotificationTitleString)
                 .setContentText(getString(R.string.notification_view))
                 .setSmallIcon(getFinishedIconDrawable())
@@ -317,6 +357,29 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
         if (mNotificationShowing) {
             // Only actually call build if it's showing
             mNotificationManager.notify(mProgressNotificationId, mProgressNotificationBuilder.build());
+        }
+    }
+
+    /**
+     * Oreo devices and higher require notifications to be placed in a "Channel" so that users can
+     * tweak similar notifications settings.
+     * Details here: https://developer.android.com/guide/topics/ui/notifiers/notifications.html
+     * <p>
+     * Here we create a "Default notifications" channel for the app if it doesn't exist.
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    private void createChannel() {
+        final boolean exists = mNotificationManager.getNotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID) != null;
+        if (!exists) {
+            final CharSequence name = getString(getNotificationChannelName());
+            final String description = getString(getNotificationChannelDescription());
+            final int importance = NotificationManager.IMPORTANCE_HIGH;
+            final NotificationChannel channel = new NotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID,
+                                                                        name,
+                                                                        importance);
+            channel.setDescription(description);
+            channel.setShowBadge(true);
+            mNotificationManager.createNotificationChannel(channel);
         }
     }
     // </editor-fold>

--- a/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
@@ -279,6 +279,7 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
         mProgressNotificationBuilder
                 .setSmallIcon(getProgressIconDrawable())
                 .setTicker(getString(R.string.notification_started))
+                .setOnlyAlertOnce(true)
                 .setProgress(100, 0, true)
                 // Example: "Uploading video"
                 .setContentTitle(getProgressNotificationString())

--- a/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
@@ -48,8 +48,6 @@ import android.support.annotation.StringRes;
  */
 public abstract class NotificationTaskService<T extends BaseTask> extends BaseTaskService<T> {
 
-    private static final String DEFAULT_NOTIFICATION_CHANNEL_ID = "turnstile_notification_channel";
-
     /**
      * Unique id for the notification. We use it on notification start and to cancel it.
      */
@@ -149,6 +147,17 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
      */
     @PluralsRes
     protected abstract int getProgressNotificationTitleStringRes();
+
+    /**
+     * The notification channel ID.
+     * Starting with Android Oreo, all notification must be grouped into channels,
+     * allowing the user to customize notification at a more granular level.
+     * This value must be unique to the application.
+     * It is not seen by the end user.
+     *
+     * @return the string resource for the notification channel ID.
+     */
+    protected abstract String getNotificationChannelId();
 
     /**
      * The notification channel name.
@@ -262,7 +271,7 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
     protected void setupNotification() {
         if (VERSION.SDK_INT >= VERSION_CODES.O) {
             createChannel();
-            mProgressNotificationBuilder = new Builder(this, DEFAULT_NOTIFICATION_CHANNEL_ID);
+            mProgressNotificationBuilder = new Builder(this, getNotificationChannelId());
         } else {
             mProgressNotificationBuilder = new Builder(this);
         }
@@ -321,7 +330,7 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
         final Notification.Builder builder;
         if (VERSION.SDK_INT >= VERSION_CODES.O) {
             createChannel();
-            builder = new Builder(this, DEFAULT_NOTIFICATION_CHANNEL_ID);
+            builder = new Builder(this, getNotificationChannelId());
         } else {
             builder = new Builder(this);
         }
@@ -375,12 +384,12 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
      */
     @RequiresApi(Build.VERSION_CODES.O)
     private void createChannel() {
-        final boolean exists = mNotificationManager.getNotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID) != null;
+        final boolean exists = mNotificationManager.getNotificationChannel(getNotificationChannelId()) != null;
         if (!exists) {
             final CharSequence name = getString(getNotificationChannelName());
             final String description = getString(getNotificationChannelDescription());
             final int importance = NotificationManager.IMPORTANCE_HIGH;
-            final NotificationChannel channel = new NotificationChannel(DEFAULT_NOTIFICATION_CHANNEL_ID,
+            final NotificationChannel channel = new NotificationChannel(getNotificationChannelId(),
                                                                         name,
                                                                         importance);
             channel.setDescription(description);
@@ -388,5 +397,6 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
             mNotificationManager.createNotificationChannel(channel);
         }
     }
+
     // </editor-fold>
 }

--- a/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/NotificationTaskService.java
@@ -152,6 +152,9 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
 
     /**
      * The notification channel name.
+     * Starting with Android Oreo, all notification must be grouped into channels,
+     * allowing the user to customize notification at a more granular level.
+     * This text will appear in the system application settings screen.
      *
      * @return the string resource for the notification channel name.
      */
@@ -160,6 +163,9 @@ public abstract class NotificationTaskService<T extends BaseTask> extends BaseTa
 
     /**
      * The notification channel description.
+     * Starting with Android Oreo, all notification must be grouped into channels,
+     * allowing the user to customize notification at a more granular level.
+     * This text will appear in the system application settings screen.
      *
      * @return the string resource for the notification channel description.
      */


### PR DESCRIPTION
#### Ticket
[VA-2757](https://vimean.atlassian.net/browse/VA-2757)

#### Ticket Summary
Starting with Android Oreo, notification channels are required when displaying notifications.  Updated our code to require library implementations to provide id, name, and description values for a channel that will be created.

#### Implementation Summary
- Updated SDK and build tools versions.
- Create and use a new channel when a notification is displayed.
- Updated sample app

#### How to Test
- Notifications will now show correctly again on O+ devices.
- Ensure provided channel name and descriptions are displayed in application settings.
