### PR TITLE
VA-3250 Adding a pause event

### DIFF
--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
@@ -303,8 +303,7 @@ public abstract class BaseTask implements Serializable, Callable {
             TaskLogger.getLogger().d("Task Started For First Time " + mId);
             execute();
         }
-        TaskLogger.getLogger().e("Task State after execute:" + mState.name());
-        if (!isComplete() && !isError() && mStateListener != null) {
+        if (mState != TaskState.COMPLETE && mState != TaskState.ERROR && mStateListener != null) {
             mStateListener.notifyOnTaskPaused(this);
         }
         mIsRunning = false;

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
@@ -303,6 +303,7 @@ public abstract class BaseTask implements Serializable, Callable {
             TaskLogger.getLogger().d("Task Started For First Time " + mId);
             execute();
         }
+        TaskLogger.getLogger().e("Task State after execute:" + mState.name());
         if (!isComplete() && !isError() && mStateListener != null) {
             mStateListener.notifyOnTaskPaused(this);
         }

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
@@ -303,7 +303,8 @@ public abstract class BaseTask implements Serializable, Callable {
             TaskLogger.getLogger().d("Task Started For First Time " + mId);
             execute();
         }
-        if (mState != TaskState.COMPLETE && mState != TaskState.ERROR && mStateListener != null) {
+        TaskLogger.getLogger().e("Task State after execute:" + mState.name());
+        if (!isComplete() && !isError() && mStateListener != null) {
             mStateListener.notifyOnTaskPaused(this);
         }
         mIsRunning = false;

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
@@ -80,6 +80,8 @@ public abstract class BaseTask implements Serializable, Callable {
 
         abstract void onTaskStarted(@NonNull T task);
 
+        abstract void onTaskPaused(@NonNull T task);
+
         abstract void onTaskStateChange(@NonNull T task);
 
         abstract void onTaskCompleted(@NonNull T task);
@@ -92,6 +94,13 @@ public abstract class BaseTask implements Serializable, Callable {
             T safeTask = getFrom(task);
             if (safeTask != null) {
                 onTaskStarted(safeTask);
+            }
+        }
+
+        public final void notifyOnTaskPaused(@NonNull BaseTask task) {
+            T safeTask = getFrom(task);
+            if (safeTask != null) {
+                onTaskPaused(safeTask);
             }
         }
 
@@ -293,6 +302,9 @@ public abstract class BaseTask implements Serializable, Callable {
         } else {
             TaskLogger.getLogger().d("Task Started For First Time " + mId);
             execute();
+        }
+        if (mState != TaskState.COMPLETE && mState != TaskState.ERROR && mStateListener != null) {
+            mStateListener.notifyOnTaskPaused(this);
         }
         mIsRunning = false;
         return null;

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
@@ -80,8 +80,6 @@ public abstract class BaseTask implements Serializable, Callable {
 
         abstract void onTaskStarted(@NonNull T task);
 
-        abstract void onTaskPaused(@NonNull T task);
-
         abstract void onTaskStateChange(@NonNull T task);
 
         abstract void onTaskCompleted(@NonNull T task);
@@ -94,13 +92,6 @@ public abstract class BaseTask implements Serializable, Callable {
             T safeTask = getFrom(task);
             if (safeTask != null) {
                 onTaskStarted(safeTask);
-            }
-        }
-
-        public final void notifyOnTaskPaused(@NonNull BaseTask task) {
-            T safeTask = getFrom(task);
-            if (safeTask != null) {
-                onTaskPaused(safeTask);
             }
         }
 
@@ -302,9 +293,6 @@ public abstract class BaseTask implements Serializable, Callable {
         } else {
             TaskLogger.getLogger().d("Task Started For First Time " + mId);
             execute();
-        }
-        if (mState != TaskState.COMPLETE && mState != TaskState.ERROR && mStateListener != null) {
-            mStateListener.notifyOnTaskPaused(this);
         }
         mIsRunning = false;
         return null;

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTask.java
@@ -303,7 +303,6 @@ public abstract class BaseTask implements Serializable, Callable {
             TaskLogger.getLogger().d("Task Started For First Time " + mId);
             execute();
         }
-        TaskLogger.getLogger().e("Task State after execute:" + mState.name());
         if (!isComplete() && !isError() && mStateListener != null) {
             mStateListener.notifyOnTaskPaused(this);
         }

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
@@ -370,6 +370,11 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
         }
 
         @Override
+        void onTaskPaused(@NonNull T task) {
+            broadcastTaskEvent(task, TaskConstants.EVENT_PAUSED);
+        }
+
+        @Override
         public void onTaskStateChange(@NonNull T task) {
             mTaskCache.upsert(task);
             // After a retry, lets make sure the service is running
@@ -723,14 +728,10 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
         }
     }
 
-    private void pauseAll() {
+    private static void pauseAll() {
         // Issues interrupts to all threads
-        for (Map.Entry<String,Future> entry : sTaskPool.entrySet()){
-            T task = getTask(entry.getKey());
-            if(task != null){
-                broadcastTaskEvent(task, TaskConstants.EVENT_PAUSED);
-            }
-            entry.getValue().cancel(true);
+        for (Future future : sTaskPool.values()) {
+            future.cancel(true);
         }
         sTaskPool.clear();
     }

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
@@ -370,11 +370,6 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
         }
 
         @Override
-        void onTaskPaused(@NonNull T task) {
-            broadcastTaskEvent(task, TaskConstants.EVENT_PAUSED);
-        }
-
-        @Override
         public void onTaskStateChange(@NonNull T task) {
             mTaskCache.upsert(task);
             // After a retry, lets make sure the service is running
@@ -728,10 +723,14 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
         }
     }
 
-    private static void pauseAll() {
+    private void pauseAll() {
         // Issues interrupts to all threads
-        for (Future future : sTaskPool.values()) {
-            future.cancel(true);
+        for (Map.Entry<String,Future> entry : sTaskPool.entrySet()){
+            T task = getTask(entry.getKey());
+            if(task != null){
+                broadcastTaskEvent(task, TaskConstants.EVENT_PAUSED);
+            }
+            entry.getValue().cancel(true);
         }
         sTaskPool.clear();
     }

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
@@ -723,10 +723,14 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
         }
     }
 
-    private static void pauseAll() {
+    private void pauseAll() {
         // Issues interrupts to all threads
-        for (Future future : sTaskPool.values()) {
-            future.cancel(true);
+        for (Map.Entry<String,Future> entry : sTaskPool.entrySet()){
+            T task = getTask(entry.getKey());
+            if(task != null){
+                broadcastTaskEvent(task, TaskConstants.EVENT_PAUSED);
+            }
+            entry.getValue().cancel(true);
         }
         sTaskPool.clear();
     }
@@ -959,6 +963,9 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
         public void onStarted(@NonNull T task) {
         }
 
+        public void onPaused(@NonNull T task) {
+        }
+
         public void onProgress(@NonNull T task, int progress) {
         }
 
@@ -1067,6 +1074,9 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
                             break;
                         case TaskConstants.EVENT_CANCELLED:
                             listener.onCanceled(task);
+                            break;
+                        case TaskConstants.EVENT_PAUSED:
+                            listener.onPaused(task);
                             break;
                         default:
                             listener.onAdditionalTaskEvent(task, event);

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
@@ -49,7 +49,6 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -745,14 +744,13 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
             return false;
         }
         isResuming = true;
-        
-        for (Entry<String, Future> element : sTaskPool.entrySet()) {
-            String taskId = element.getKey();
-            if (!isQueued(taskId)) {
-                removeFromTaskPool(taskId);
-            }
+        // Only resume for network if the tasks aren't paused and it's not in the process of resuming
+        // Issues interrupts to all threads
+        for (Future future : sTaskPool.values()) {
+            future.cancel(true);
         }
-
+        // Clear the task pool because all the necessary tasks will be re-added
+        sTaskPool.clear();
         // TODO: iterate through all threads with the task id and stop them 11/5/15 [KV]
         // I've seen threads survive the service dying
         // http://stackoverflow.com/questions/6667496/get-reference-to-thread-object-from-its-id

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
@@ -49,6 +49,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -744,13 +745,14 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
             return false;
         }
         isResuming = true;
-        // Only resume for network if the tasks aren't paused and it's not in the process of resuming
-        // Issues interrupts to all threads
-        for (Future future : sTaskPool.values()) {
-            future.cancel(true);
+        
+        for (Entry<String, Future> element : sTaskPool.entrySet()) {
+            String taskId = element.getKey();
+            if (!isQueued(taskId)) {
+                removeFromTaskPool(taskId);
+            }
         }
-        // Clear the task pool because all the necessary tasks will be re-added
-        sTaskPool.clear();
+
         // TODO: iterate through all threads with the task id and stop them 11/5/15 [KV]
         // I've seen threads survive the service dying
         // http://stackoverflow.com/questions/6667496/get-reference-to-thread-object-from-its-id

--- a/turnstile/src/main/java/com/vimeo/turnstile/TaskConstants.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/TaskConstants.java
@@ -47,7 +47,7 @@ final class TaskConstants {
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
             EVENT_PROGRESS, EVENT_SUCCESS, EVENT_FAILURE, EVENT_RETRYING, EVENT_ADDED, EVENT_CANCELLED,
-            EVENT_STARTED
+            EVENT_STARTED, EVENT_PAUSED
     })
     public @interface TaskEvent {}
 
@@ -65,6 +65,7 @@ final class TaskConstants {
     public static final String EVENT_ADDED = "EVENT_ADDED";
     public static final String EVENT_STARTED = "EVENT_STARTED";
     public static final String EVENT_CANCELLED = "EVENT_CANCELLED";
+    public static final String EVENT_PAUSED = "EVENT_PAUSED";
 
     public static final String EVENT_RESUME_IF_NECESSARY = "EVENT_RESUME_IF_NECESSARY";
     public static final String EVENT_ALL_TASKS_FINISHED = "EVENT_ALL_TASKS_FINISHED";


### PR DESCRIPTION
#### Ticket
[VA-3250](https://vimean.atlassian.net/browse/VA-3250)

#### Ticket Summary
In order to accurately log upload durations in Fresnel, we need to know when an upload task has been paused and resumed. We already have start event, but we need to send a pause event for a task to track things accurately.

#### Implementation Summary
Added an `onPaused` event to the `TaskEventListener` and invoke it when `pauseAll()` is called in the `BaseTaskManager`.


