### PR TITLE
Adding specific retry event, fixing task deserialization, and updating build tools and gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
   - platform-tools
   - platform-tools-preview
   - android-27
-  - build-tools-27.0.3
+  - build-tools-28.0.3
   - extra-android-m2repository
   - extra-google-google_play_services
   - extra-google-m2repository

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,12 @@
 
 buildscript {
     repositories {
+        maven { url "https://maven.google.com" }
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
+        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Apr 03 10:58:41 EDT 2017
+#Tue Dec 11 17:38:56 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "com.vimeo.sample"
@@ -24,7 +24,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:27.0.2'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
 
-    compile project(':turnstile')
+    implementation project(':turnstile')
 }

--- a/turnstile/build.gradle
+++ b/turnstile/build.gradle
@@ -28,7 +28,7 @@ ext {
 
 android {
     compileSdkVersion 27 // Update .travis.yml android.components.android-*
-    buildToolsVersion "27.0.3" // Update .travis.yml android.components.build-tools-*
+    buildToolsVersion "28.0.3" // Update .travis.yml android.components.build-tools-*
 
     defaultConfig {
         minSdkVersion 16
@@ -38,10 +38,10 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.robolectric:robolectric:3.1.2'
-    compile 'com.android.support:support-annotations:27.0.2'
-    compile 'com.google.code.gson:gson:2.7'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.robolectric:robolectric:3.1.2'
+    implementation 'com.android.support:support-annotations:27.0.2'
+    implementation 'com.google.code.gson:gson:2.7'
 }
 
 //apply from: 'https://raw.githubusercontent.com/nuuneoi/JCenter/master/installv1.gradle'

--- a/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/BaseTaskManager.java
@@ -1089,8 +1089,11 @@ public abstract class BaseTaskManager<T extends BaseTask> implements Conditions.
                         case TaskConstants.EVENT_SUCCESS:
                             listener.onSuccess(task);
                             break;
-                        case TaskConstants.EVENT_MANAGER_RETRY:
+                        case TaskConstants.EVENT_RETRY:
                             listener.onRetry(task);
+                            break;
+                        case TaskConstants.EVENT_MANAGER_RETRY:
+                            listener.onManagerRetry(task);
                             break;
                         case TaskConstants.EVENT_ADDED:
                             listener.onAdded(task);

--- a/turnstile/src/main/java/com/vimeo/turnstile/TaskConstants.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/TaskConstants.java
@@ -46,7 +46,7 @@ final class TaskConstants {
     // ---- Broadcast Events ----
     @Retention(RetentionPolicy.SOURCE)
     @StringDef({
-            EVENT_PROGRESS, EVENT_SUCCESS, EVENT_FAILURE, EVENT_RETRYING, EVENT_ADDED, EVENT_CANCELLED,
+            EVENT_PROGRESS, EVENT_SUCCESS, EVENT_FAILURE, EVENT_RETRY, EVENT_MANAGER_RETRY, EVENT_ADDED, EVENT_CANCELLED,
             EVENT_STARTED, EVENT_PAUSED
     })
     public @interface TaskEvent {}
@@ -61,7 +61,8 @@ final class TaskConstants {
     public static final String EVENT_PROGRESS = "EVENT_PROGRESS";
     public static final String EVENT_SUCCESS = "EVENT_SUCCESS";
     public static final String EVENT_FAILURE = "EVENT_FAILURE";
-    public static final String EVENT_RETRYING = "EVENT_RETRYING";
+    public static final String EVENT_RETRY = "EVENT_RETRY";
+    public static final String EVENT_MANAGER_RETRY = "EVENT_MANAGER_RETRY";
     public static final String EVENT_ADDED = "EVENT_ADDED";
     public static final String EVENT_STARTED = "EVENT_STARTED";
     public static final String EVENT_CANCELLED = "EVENT_CANCELLED";

--- a/turnstile/src/main/java/com/vimeo/turnstile/TaskError.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/TaskError.java
@@ -92,7 +92,13 @@ public class TaskError implements Serializable {
             String domain = jsonObject.getString(DOMAIN);
             int code = jsonObject.getInt(CODE);
             String message = jsonObject.getString(MESSAGE);
-            Exception exception = (Exception) jsonObject.opt(EXCEPTION);
+            Exception exception = null;
+            try {
+                exception = (Exception) jsonObject.opt(EXCEPTION);
+            } catch (ClassCastException classCastException) {
+                TaskLogger.getLogger().e("Unable to deserialize exception on TaskError: "
+                                         + classCastException.getMessage());
+            }
 
             return new TaskError(domain, code, message, exception);
         }

--- a/turnstile/src/main/java/com/vimeo/turnstile/TaskError.java
+++ b/turnstile/src/main/java/com/vimeo/turnstile/TaskError.java
@@ -175,19 +175,21 @@ public class TaskError implements Serializable {
     /**
      * Convert the Throwable to an {@link Exception}. There have been issues
      * with exception serialization and deserialization.
-     *
+     * <p>
      * A longer term solution will be moving away from holding an Exception at all.
      */
-    public void setException(@Nullable Throwable exception) {
+    public void setException(@Nullable final Throwable exception) {
         if (exception == null) {
             mException = null;
         } else {
             String exceptionMessage = exception.getMessage();
-            if (exceptionMessage != null) {
-                // replaceAll() so that we don't have more than one layer of nesting (this could happen
-                // with deserialization).
-                mException = new Exception(exceptionMessage.replaceAll("java.lang.Exception: ", ""));
+            if (exceptionMessage == null || exception.getClass() == null || exception.getClass().getName() == null) {
+                return;
             }
+            exceptionMessage = exception.getClass().getName() + ": " + exceptionMessage;
+            // replaceAll() so that we don't have more than one layer of nesting (this could happen
+            // with deserialization).
+            mException = new Exception(exceptionMessage.replaceAll("java.lang.Exception: ", ""));
         }
     }
     // </editor-fold>


### PR DESCRIPTION
#### Ticket Summary
This change is to increase the granularity of logging for retries and fix exception deserialization errors.

#### Implementation Summary
* I updated the build tools and gradle versions.
* Compile -> implementation

##### Exception deserialization issue
I've changed how exceptions are deserialized further. We originally made a change to wrap the Exception in another exception since there were custom exception implementations that would cause a crash when serializing. We now are unable to deserialize exceptions just of type `Exception`. So I've changed the logic to serialize it as the message string and deserialize it by initializing an exception with that message (the previous behavior was a failure). We'll still retain the type of the exception with this method. 

See the application PR for more information.

[Crash](https://rink.hockeyapp.net/manage/apps/196877/app_versions/39/crash_reasons/125691916)
[Fix for crash](https://github.com/vimeo/turnstile-android/pull/12)
[Ticket for improving it further](https://github.com/vimeo/turnstile-android/issues/25)

##### More thorough retry logging
* I renamed the onRetry to onManagerRetry since that event only represents when the manager retries a task.
* I created a new onTaskRetry event which will get fired anytime `updateStateForRetry()` is called to allow for more specific insight into when a task is being retried (whether it's automatic or manual).

#### How to Test
* Get a task to enter the failed state. Close the app and reopen it. Ensure that the task deserializes correctly.
* Ensure onManagerRetry is fired at the same intervals is was before.